### PR TITLE
fixed container style

### DIFF
--- a/app/assets/stylesheets/components/_checkout.scss
+++ b/app/assets/stylesheets/components/_checkout.scss
@@ -1,0 +1,3 @@
+// .container {
+//   max-width: 960px;
+// }


### PR DESCRIPTION
![checkout scss](https://github.com/KarasuGummi/okasan_food/assets/111837513/abfb3d52-5e11-4479-b656-0d98408be292)
![containter](https://github.com/KarasuGummi/okasan_food/assets/111837513/bf4e7fd1-609a-4a42-8801-6ff85e824915)
 

I commented out the ".container" part since all style will be changed if we set size of container
@favio102 
Sorry, it might break your style but is it possible to change the name from .container to something else?:)
Thank you!