### PR TITLE
updated listing model to destroy reviews for new seeds

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -4,7 +4,7 @@ class Listing < ApplicationRecord
   # Uncomment once active storage has been installed
   has_one_attached :photo
   has_many :bookings
-  has_many :reviews
+  has_many :reviews, dependent: :destroy
 
   include PgSearch::Model
   pg_search_scope :search_by_name_and_category, against: [ :name, :category ],using: {


### PR DESCRIPTION
I was receiving an error when I tried to run rails db:seed so I tried to fix it by adding dependent: :destroy to has_many reviews

<img width="661" alt="Screen Shot 2023-07-29 at 14 14 25" src="https://github.com/KarasuGummi/okasan_food/assets/115050264/243490d6-f7b2-4279-952f-1f50e58a014c">
